### PR TITLE
Grammar fixes to DART cuts post

### DIFF
--- a/_posts/dart-cuts.md
+++ b/_posts/dart-cuts.md
@@ -46,7 +46,7 @@ and finally
 
 The cities had reached out for a study, NCTCOG started working on it, and in the meantime, the cities do exactly the opposite of the current recommendations. Why ask for help in the first place?
 
-In spite of this firm letter, the cities continue with the cuts.
+In spite of this firm letter, the cities continue supporting the cuts.
 
 ## Rowlett
 July 2nd - Rowlett's city council put forward a resolution with identical wording to Plano's. Plano's presenter sounded like a politician, talking about going to the Texas legislature, including only facts that support their narrative, and using careful wording to imply certain things without actually saying them. On the other hand, Rowlett's presentation was a bit rougher. It included numerous errors, perplexing assumptions, and projections based off of those previous errors that gave an even more egregious result. But without the relevant background knowledge, the council voted unanimously in support of it anyways.
@@ -54,7 +54,7 @@ July 2nd - Rowlett's city council put forward a resolution with identical wordin
 A slide-by-slide fact-check of Rowlett's presentation can be seen [here](https://docs.google.com/presentation/d/1GKMZaz76c3Sck3ZZscDksqYOR-HvFt7lSw7mv2DeDCg).
 
 ## Irving
-July 11th - Irving city council had DART budget cuts on the agenda. At first, it was under the consent agenda, a part of the agenda that is supposed to contain rote items that can be voted on for approval in bulk. Many residents reached out asking for them to remove it from the consent agenda so it could've had the full discussion it deserved. Irving obliged, and citizens flocked to the meeting urging the council to vote against the resolution. Similar to Plano's council meeting, however, Irving council members made vague arguments of fiscal responsibility and examples of the cut DART funding instead paying for police and fire, or lower property taxes. The vote passed unanimously.
+July 11th - Irving city council had DART budget cuts on the agenda. At first, it was under the consent agenda, a part of the agenda that is supposed to contain rote items that can be voted on for approval in bulk. Many residents reached out asking for them to remove it from the consent agenda to give the resolution the full discussion it deserved. Irving obliged, and citizens flocked to the meeting urging the council to vote against the resolution. Similar to Plano's council meeting, however, Irving council members made vague arguments of fiscal responsibility and examples of the cut DART funding instead paying for police and fire, or lower property taxes. The vote passed unanimously.
 
 ## Garland & Richardson
 Thankfully, the councils of Garland and Richardson unanimously voted in support of DART's current funding levels, a stark contrast to their neighbors. Downtown Garland and CityLine in Richardson have been seeing a lot of development efforts around their transit centers, and it's paying dividends - so maybe it's not too surprising they're against these cuts.
@@ -62,11 +62,11 @@ Thankfully, the councils of Garland and Richardson unanimously voted in support 
 ## Carrollton & Farmers Branch
 July 16th - Carrollton and Farmers Branch had their meetings on the same day, with the same result - but the way they went about it couldn't be any different. 
 
-Carrollton's agenda item was titled "Supporting Transit 2.0". It had a lot of formal text talking about what Transit 2.0 is and why they support it, but if you read all the way to the bottom, you saw a little blurb saying that in support of Transit 2.0, they support a 25% funding cut to DART. Carrollton has a large Transit-Oriented Development being built around their Trinity Mills station, it has a connection to the Denton A-Train, and it's getting a new Silver Line station in Downtown Carrolton. They knew that cutting DART at this time of growth would be unpopular, so they hid it under language that sounds positive for transit.
+Carrollton's agenda item was titled "Supporting Transit 2.0". It had a lot of formal text talking about what Transit 2.0 is and why they support it, but if you read all the way to the bottom, you'll see a little blurb saying that *in support of Transit 2.0, they support a 25% funding cut to DART*. Carrollton has a large Transit-Oriented Development being built around their Trinity Mills station, it has a connection to the Denton A-Train, and it's getting a new Silver Line station in Downtown Carrolton. They knew that cutting DART at this time of growth would be unpopular, so they hid it under language that sounds positive for transit.
 
-After citizens spoke in protest at the meeting, the council members were confused. What does Transit 2.0 have to do with cutting DART? Why was this titled this way? But ultimately, the mayor and city attourney waved away their worries by saying this was simply a symbolic vote, and it didn't actually reduce DART funding. So it passed, 6 for, 1 against.
+After citizens spoke in protest at the meeting, the council members were confused. What does Transit 2.0 have to do with cutting DART? Why was the agenda item titled this way? Ultimately, the mayor and city attorney waved away their worries by saying this was merely a symbolic vote and didn't actually reduce DART funding. So it passed, 6 for, 1 against.
 
-Farmers Branch, conversely, was evidently hostile towards transit. Several citizens voiced their support for DART and suggested road narrowing, but to no avail. The mayor and one of the city council members voiced contempt for DART and transit, and they even said *"there's nothing but a chain link fence between them and all the **trash** that comes up here on their trains."* Unsurprisingly, it passed unanimously.
+Farmers Branch, however, was evidently hostile towards transit. Several citizens voiced their support for DART and suggested road narrowing, but to no avail. The mayor and one of the city council members voiced contempt for DART and transit, and they even said, "*there's nothing but a chain link fence between them and all the **trash** that comes up here on their trains.*" Unsurprisingly, it passed unanimously.
 
 ## What's Next
 These member cities, led by Plano and Irving, are looking to lobby at the January 2025 Texas legislature to reduce transit agency sales tax collection from 1% to 0.75%.

--- a/_posts/dart-cuts.md
+++ b/_posts/dart-cuts.md
@@ -15,7 +15,7 @@ At the time of writing this, 5 cities have voted for and 2 cities have voted aga
 ## Background
 In 2023, some member cities of DART, Trinity Metro, and DCTA sent a letter to the NCTCOG (North Central Texas Council of Governments) Regional Transportation Council asking for a comprehensive study to "assess the effectiveness of regional transit today and what regional transit should look like for the next 40 years."
 
-As the region's "neutral transportation planner", NCTCOG released their Request For Proposals (RFP) in late 2023 titled ["North Central Texas Regional Transit 2.0: Planning for Year 2050"](https://www.nctcog.org/getmedia/89832cd2-9626-44c8-bb9b-d868febce6f0/RFP-_Regional-Transit-2-0-FINAL.pdf). This document discusses topics of further research to make transit more widely available, used by many, and financially sustainable. The way to achieve those would be through:
+As the region's "neutral transportation planner", NCTCOG released their Request For Proposals (RFP) in late 2023 titled ["North Central Texas Regional Transit 2.0: Planning for Year 2050"](https://www.nctcog.org/getmedia/89832cd2-9626-44c8-bb9b-d868febce6f0/RFP-_Regional-Transit-2-0-FINAL.pdf). This document discussed ways to make transit widely available, financially sustainable, and used by many:
 
 1. Develop more aggressive transit legislation
 2. Increase transit authority membership
@@ -24,16 +24,15 @@ As the region's "neutral transportation planner", NCTCOG released their Request 
 5. Review fare collections
 6. Review the current funding system
 
-This all makes sense, it's been several decades and it's important to review the decisions in the past and see if anything should be changed or improved for the future.
+This all makes sense - it's been several decades and it's important to review past decisions to see whether anything should be changed or improved for the future.
 
 But unfortunately, some cities aren't doing that.
 
 ## Plano
-June 24th - Plano city council met to vote on a resolution supporting cutting DART's funding by 25%. Several citizens voiced their opposition to this but ultimately it passed unanimously. In July Plano [released an article by City Manager Mark Israelson](https://content.civicplus.com/api/assets/617e7bce-3680-45d8-bb90-0351d2241441) with arguments similar to his presentation on the 24th. Towards the end of the article it says *"It is time for Transit 2.0 to arrive*", which is strange considering the Transit 2.0 RFP specifically says *"Currently there is no evidence that a lower tax rate at DART is possible"*.
+June 24th - Plano city council met to vote on a resolution supporting cutting DART's funding by 25%. Several citizens voiced their opposition to this, but ultimately, it passed unanimously. In July, Plano [released an article by City Manager Mark Israelson](https://content.civicplus.com/api/assets/617e7bce-3680-45d8-bb90-0351d2241441) with arguments similar to his presentation on the 24th. Towards the end of the article, Israelson says that "it is time for Transit 2.0 to arrive," which is strange considering the Transit 2.0 RFP specifically states, **"Currently there is no evidence that a lower tax rate at DART is possible."**
 
 ## NCTCOG Weighs In
-June 28th - Michael Morris, the Director of Transportation at NCTCOG, sent an email to all of the city managers within DART. It included some strong and direct language like
-
+June 28th - Michael Morris, the Director of Transportation at NCTCOG, sent an email to all of the city managers within DART member cities. It included some strong and direct language like
 
 > *"we see non-financially supported ideas to support transit revenues used to fund pensions and proposed sales tax reductions"*
 
@@ -45,49 +44,49 @@ and finally
 
 > *"All 10 cities with highest percentage growth were outside transportation authority boundaries.  If we do not work together and turn this around, roadway funds will be lost to DART cities as well and as the RTC chases congestion, air quality and safety to the rural reaches of the region. This will reinforce even greater inefficient land use."*
 
-The cities reached out, NCTCOG started working on it, and in the meantime the cities do exactly the opposite of the current recommendations. Why ask for help in the first place?
+The cities had reached out for a study, NCTCOG started working on it, and in the meantime, the cities do exactly the opposite of the current recommendations. Why ask for help in the first place?
 
-In spite of this firm letter the cities continue on.
+In spite of this firm letter, the cities continue with the cuts.
 
 ## Rowlett
-July 2nd - Rowlett's city council put forward a resolution with the exact same wording as Plano's. Plano's presentor seemed more like a politician. They talk about going to the Texas legislature, include facts that support them, exclude things that don't, and use careful wording to makes you think something without them actually saying it. Rowlett on the other hand is a bit more rough. The presentation included numerous errors, perplexing assumptions, and then projections based off of those previous errors that give an even more egregious result. But without the relevant background knowledge the council voted unanimously in support of it anyways.
+July 2nd - Rowlett's city council put forward a resolution with identical wording to Plano's. Plano's presenter sounded like a politician, talking about going to the Texas legislature, including only facts that support their narrative, and using careful wording to imply certain things without actually saying them. On the other hand, Rowlett's presentation was a bit rougher. It included numerous errors, perplexing assumptions, and projections based off of those previous errors that gave an even more egregious result. But without the relevant background knowledge, the council voted unanimously in support of it anyways.
 
-A slide by slide fact-check of Rowlett's presentation can be seen [here](https://docs.google.com/presentation/d/1GKMZaz76c3Sck3ZZscDksqYOR-HvFt7lSw7mv2DeDCg)
+A slide-by-slide fact-check of Rowlett's presentation can be seen [here](https://docs.google.com/presentation/d/1GKMZaz76c3Sck3ZZscDksqYOR-HvFt7lSw7mv2DeDCg).
 
 ## Irving
-July 11th - Irving city council had DART budget cuts on the agenda. At first it was under the consent agenda, a part of the agenda that is supposed to contain rote items that can be voted on for approval in bulk. Many citizens reached out and asked for them to remove it from the consent agenda so it can have the full discussion it deserves. Irving obliged and many citizens attended the meeting urging them to vote against it. Similar to Plano, Irving council members made vague arguments of fiscal responsibility and examples of DART funding instead paying for police and fire, or lower property taxes. The vote passed unanimously.
+July 11th - Irving city council had DART budget cuts on the agenda. At first, it was under the consent agenda, a part of the agenda that is supposed to contain rote items that can be voted on for approval in bulk. Many residents reached out asking for them to remove it from the consent agenda so it could've had the full discussion it deserved. Irving obliged, and citizens flocked to the meeting urging the council to vote against the resolution. Similar to Plano's council meeting, however, Irving council members made vague arguments of fiscal responsibility and examples of the cut DART funding instead paying for police and fire, or lower property taxes. The vote passed unanimously.
 
 ## Garland & Richardson
-The councils of Garland and Richardson both unanimously voted in support of the current funding levels of DART, a stark difference from their neighbors. Downtown Garland and CityLine in Richardson have been seeing a lot of development effort around their transit centers and it's paying dividends; so maybe it's not too surprising they're against this.
+Thankfully, the councils of Garland and Richardson unanimously voted in support of DART's current funding levels, a stark contrast to their neighbors. Downtown Garland and CityLine in Richardson have been seeing a lot of development efforts around their transit centers, and it's paying dividends - so maybe it's not too surprising they're against these cuts.
 
 ## Carrollton & Farmers Branch
-Carrollton and Farmers Branch had their meetings on the same day, with the same result, but the way they went about it couldn't be any different. 
+July 16th - Carrollton and Farmers Branch had their meetings on the same day, with the same result - but the way they went about it couldn't be any different. 
 
-Carrollton's agenda item was titled "Supporting Transit 2.0". It had a lot of formal text talking about what Transit 2.0 is and why they support it, but if you read all the way to the bottom you see a little blurb saying that in support of Transit 2.0 they support a 25% funding cut to DART. Carrollton has a large TOD being built around their Trinity Mills station, it has a connection to the Denton A-Train, and it's getting the new Silver Line station in Downtown Carrolton. They knew that cutting DART at this time of growth would be unpopular, so they hid it under language that sounds positive for transit.
+Carrollton's agenda item was titled "Supporting Transit 2.0". It had a lot of formal text talking about what Transit 2.0 is and why they support it, but if you read all the way to the bottom, you saw a little blurb saying that in support of Transit 2.0, they support a 25% funding cut to DART. Carrollton has a large Transit-Oriented Development being built around their Trinity Mills station, it has a connection to the Denton A-Train, and it's getting a new Silver Line station in Downtown Carrolton. They knew that cutting DART at this time of growth would be unpopular, so they hid it under language that sounds positive for transit.
 
-After citizens spoke in protest at the meeting, the council members were confused. What does Transit 2.0 have to do with cutting DART? Why was this titled this way? But ultimately the mayor and city attourney waved away their worries by saying this is just a symbolic vote, it doesn't actually reduce DART funding. So it passed, 6 for, 1 against.
+After citizens spoke in protest at the meeting, the council members were confused. What does Transit 2.0 have to do with cutting DART? Why was this titled this way? But ultimately, the mayor and city attourney waved away their worries by saying this was simply a symbolic vote, and it didn't actually reduce DART funding. So it passed, 6 for, 1 against.
 
-Farmers Branch on the other hand was more hostile towards transit. Several citizens voiced their support for DART and also suggested ride narrowing. The mayor and one of the city council members voiced contempt for DART, transit, and even said *"there's nothing but a chain link fence between them and all the **trash** that comes here on their train"*. Unsurprisingly, it also passed unanimously.
+Farmers Branch, conversely, was evidently hostile towards transit. Several citizens voiced their support for DART and suggested road narrowing, but to no avail. The mayor and one of the city council members voiced contempt for DART and transit, and they even said *"there's nothing but a chain link fence between them and all the **trash** that comes here on their trains"*. Unsurprisingly, it passed unanimously.
 
 ## What's Next
-These member cities, led by Plano and Irving, are looking to lobby at the January 2025 Texas legislature to reduce the amount a transit agency can collect from 1% sales tax to 0.75%.
+These member cities, led by Plano and Irving, are looking to lobby at the January 2025 Texas legislature to reduce transit agency sales tax collection from 1% to 0.75%.
 
 Dallas has mentioned they will vote on this at an upcoming September meeting.
 
-## Current voting status:
+## Current voting statuses:
 
-Cities FOR budget cuts
+Cities FOR budget cuts:
 - Carrollton: 6 for - 1 against
 - Farmers Branch: 5 for - 0 against
 - Irving: 8 for - 0 against
 - Plano: 7 for - 0 against
 - Rowlett: 6 for - 0 against
 
-Cities AGAINST budget cuts
+Cities AGAINST budget cuts:
 - Garland
 - Richardson
 
-Cities that haven't voted
+Cities that haven't voted:
 - Addison
 - Cockrell Hill
 - Dallas

--- a/_posts/dart-cuts.md
+++ b/_posts/dart-cuts.md
@@ -66,7 +66,7 @@ Carrollton's agenda item was titled "Supporting Transit 2.0". It had a lot of fo
 
 After citizens spoke in protest at the meeting, the council members were confused. What does Transit 2.0 have to do with cutting DART? Why was this titled this way? But ultimately, the mayor and city attourney waved away their worries by saying this was simply a symbolic vote, and it didn't actually reduce DART funding. So it passed, 6 for, 1 against.
 
-Farmers Branch, conversely, was evidently hostile towards transit. Several citizens voiced their support for DART and suggested road narrowing, but to no avail. The mayor and one of the city council members voiced contempt for DART and transit, and they even said *"there's nothing but a chain link fence between them and all the **trash** that comes here on their trains"*. Unsurprisingly, it passed unanimously.
+Farmers Branch, conversely, was evidently hostile towards transit. Several citizens voiced their support for DART and suggested road narrowing, but to no avail. The mayor and one of the city council members voiced contempt for DART and transit, and they even said *"there's nothing but a chain link fence between them and all the **trash** that comes up here on their trains."* Unsurprisingly, it passed unanimously.
 
 ## What's Next
 These member cities, led by Plano and Irving, are looking to lobby at the January 2025 Texas legislature to reduce transit agency sales tax collection from 1% to 0.75%.

--- a/_posts/dart-cuts.md
+++ b/_posts/dart-cuts.md
@@ -1,6 +1,6 @@
 ---
 title: "Background on DART cuts"
-excerpt: "At the time of writing this, 5 cities have voted for, and 2 cities have voted against a reduction in DART's funding by 25%. Here's how we got here and what's coming next."
+excerpt: "At the time of writing this, 5 cities have voted for and 2 cities have voted against a reduction in DART's funding by 25%. Here's how we got here and what's coming next."
 coverImage: "/assets/blog/dart-cuts/cover.jpg"
 date: "2024-07-26T05:00:00.000Z"
 author:
@@ -10,12 +10,12 @@ ogImage:
   url: "/assets/blog/dart-cuts/cover.jpg"
 ---
 
-At the time of writing this, 5 cities have voted for, and 2 cities have voted against a reduction in DART's funding by 25%. Here's how we got here and what's coming next.
+At the time of writing this, 5 cities have voted for and 2 cities have voted against a reduction in DART's funding by 25%. Here's how we got here and what's coming next.
 
 ## Background
-In 2023 some of the member cities of DART, Trinity Metro, and DCTA sent a letter to NCTCOG (North Central Texas Council of Governments) Regional Transportation Council asking for a comprehensive study to *"assess the effectiveness of regional transit today and what regional transit should look like for the next 40 years"*. They asked NCTCOG because they the region's *"neutral transportation planner"*.
+In 2023, some member cities of DART, Trinity Metro, and DCTA sent a letter to the NCTCOG (North Central Texas Council of Governments) Regional Transportation Council asking for a comprehensive study to "assess the effectiveness of regional transit today and what regional transit should look like for the next 40 years."
 
-NCTCOG released their Request For Proposals (RFP) in late 2023 titled [*"North Central Texas Regional Transit 2.0: Planning for Year 2050"*](https://www.nctcog.org/getmedia/89832cd2-9626-44c8-bb9b-d868febce6f0/RFP-_Regional-Transit-2-0-FINAL.pdf). It writes about wanting to research the best way to make transit more widely available, used by many, and financially sustainable. The way to achieve those would be through:
+As the region's "neutral transportation planner", NCTCOG released their Request For Proposals (RFP) in late 2023 titled ["North Central Texas Regional Transit 2.0: Planning for Year 2050"](https://www.nctcog.org/getmedia/89832cd2-9626-44c8-bb9b-d868febce6f0/RFP-_Regional-Transit-2-0-FINAL.pdf). This document discusses topics of further research to make transit more widely available, used by many, and financially sustainable. The way to achieve those would be through:
 
 1. Develop more aggressive transit legislation
 2. Increase transit authority membership

--- a/_posts/myths-facts.md
+++ b/_posts/myths-facts.md
@@ -15,16 +15,12 @@ ogImage:
 There are some statements that cities or elected officials have been making that are incorrect regarding DART and their services, funding, or safety. DATA has complied some of them and debunked every myth. 
 
 ---
-## Myth: Cutting DART's funding won't impact service.
-**Fact**: The NCTCOG Transit 2.0 RFP does not call for cutting DART sales tax. Instead, it stated:   
+## Myth: DART's sales tax cut won't impact service.
+**Fact**: DART's Chief Communications Officer, Jeamy Molina, has clearly stated that any cut to DART's sales tax could result in reduced services, staff layoffs, and a significant funding loss of nearly **$6 billion** over the next 20 years. Furthermore, the North Central Texas Council of Governments (NCTCOG) does not call for cutting DART sales tax in its Transit 2.0 Request For Proposal (RFP), a study requested by DART's member cities into improving transit for the next 40 years. Instead, it stated:   
 > “Currently there is no evidence that a lower tax rate at DART is possible. If it is possible, what are the impacts to **service, debt obligations and future service commitments**.” 
 
 Without careful consideration, these cuts could jeopardize critical projects like the Silver Line or the Tier 2 Bus Network.  
-*Source: [NCTCOG Transit 2.0 RFP](https://www.nctcog.org/getmedia/89832cd2-9626-44c8-bb9b-d868febce6f0/RFP-_Regional-Transit-2-0-FINAL.pdf)*
-
-## Myth: DART's sales tax cut will not impact services significantly.
-**Fact**: DART's Chief Communications Officer, Jeamy Molina, has clearly stated that any cut to the DART sales tax could result in reduced services, staff layoffs, and a significant funding loss of nearly **$6 billion** over the next 20 years.  
-*Source: [KDFW FOX 4](https://www.fox4news.com/news/farmers-branch-dart-trash-money), [WFAA ABC 8](https://www.wfaa.com/article/news/local/dallas-county/farmers-branch-councilman-dart-trash-comment/287-8e2c934d-5c2c-4c14-99f4-50da22838c74)*
+*Source: [NCTCOG Transit 2.0 RFP](https://www.nctcog.org/getmedia/89832cd2-9626-44c8-bb9b-d868febce6f0/RFP-_Regional-Transit-2-0-FINAL.pdf), [KDFW FOX 4](https://www.fox4news.com/news/farmers-branch-dart-trash-money), [WFAA ABC 8](https://www.wfaa.com/article/news/local/dallas-county/farmers-branch-councilman-dart-trash-comment/287-8e2c934d-5c2c-4c14-99f4-50da22838c74)*
 
 ## Myth: DART is not expanding its services.
 **Fact**: DART's phase 2 (also known as tier 2) bus network is giving all member cities a massive boost in bus service, especially on the highest performing routes. This includes many over-performing suburban bus routes that DART is rewarding with extra frequent service. The phase 2 bus network gives the average DART resident access to 30% more jobs within an hour commute. DART has started implementing their new bus network this year with new bus routes in Irving and Plano, and with frequency boosts on the light rail.  

--- a/_posts/myths-facts.md
+++ b/_posts/myths-facts.md
@@ -16,20 +16,19 @@ There are some statements that cities or elected officials have been making that
 
 ---
 ## Myth: Cutting DART's funding won't impact service.
-**Fact**: The NCTCOG Transit 2.0 RFP does not call for a cutting in the DART sales tax, it has been stated that   
+**Fact**: The NCTCOG Transit 2.0 RFP does not call for cutting DART sales tax. Instead, it stated:   
 > “Currently there is no evidence that a lower tax rate at DART is possible. If it is possible, what are the impacts to **service, debt obligations and future service commitments**.” 
 
 Without careful consideration, these cuts could jeopardize critical projects like the Silver Line or the Tier 2 Bus Network.  
 *Source: [NCTCOG Transit 2.0 RFP](https://www.nctcog.org/getmedia/89832cd2-9626-44c8-bb9b-d868febce6f0/RFP-_Regional-Transit-2-0-FINAL.pdf)*
 
 ## Myth: DART's sales tax cut will not impact services significantly.
-**Fact**: DART's Chief Communications Officer, Jeamy Molina, has clearly stated that any cut to the DART sales use tax could result in reduced services, staff layoffs, and a significant funding loss of nearly **$6 billion** over the next 20 years.  
+**Fact**: DART's Chief Communications Officer, Jeamy Molina, has clearly stated that any cut to the DART sales tax could result in reduced services, staff layoffs, and a significant funding loss of nearly **$6 billion** over the next 20 years.  
 *Source: [KDFW FOX 4](https://www.fox4news.com/news/farmers-branch-dart-trash-money), [WFAA ABC 8](https://www.wfaa.com/article/news/local/dallas-county/farmers-branch-councilman-dart-trash-comment/287-8e2c934d-5c2c-4c14-99f4-50da22838c74)*
 
 ## Myth: DART is not expanding its services.
-**Fact**: DART's phase 2 (also known as tier 2) bus network is giving all member cities a massive boost in bus service, especially on the highest performing routes. This includes many over-performing suburban bus routes that DART is rewarding with extra frequent service. The phase 2 bus network gives the average DART resident access to 30% more jobs within an hour commute. DART has started implementing their new bus network this year with new bus routes in Irving and Plano, and frequency boosts on the light rail.  
+**Fact**: DART's phase 2 (also known as tier 2) bus network is giving all member cities a massive boost in bus service, especially on the highest performing routes. This includes many over-performing suburban bus routes that DART is rewarding with extra frequent service. The phase 2 bus network gives the average DART resident access to 30% more jobs within an hour commute. DART has started implementing their new bus network this year with new bus routes in Irving and Plano, and with frequency boosts on the light rail.  
 *Source: [DART News Release](https://www.dart.org/about/news-and-events/newsreleases/newsrelease-detail/dart-to-expand-golink-services--roll-out-new-bus-routes)*
-
 
 ## Myth: DART's ridership is declining.
 **Fact**: While the pandemic caused a temporary decline, DART's ridership has been recovering rapidly. The notion that ridership is continuously declining is misleading; recent trends show significant growth.  
@@ -51,5 +50,5 @@ A dedicated Real Estate & Economic Development Department was established to sup
 
 ---
 # Bottom Line
-DART is proactively addressing customer concerns, expanding services, and improving overall transit quality. Cutting DART's funding would undermine these efforts, despite the clear evidence of progress and growth in ridership. DART's continuous improvements and strategic vision showcase a commitment to enhancing transit for the community, making any funding cuts counterproductive.
+DART is proactively addressing customer concerns, expanding services, and improving overall transit quality. Cutting DART's funding would undermine these efforts, despite growth in ridership and clear evidence of progress. DART's continuous improvement and strategic vision showcase a commitment to enhancing transit for the community, making any funding cuts counterproductive.
 

--- a/_posts/myths-facts.md
+++ b/_posts/myths-facts.md
@@ -1,6 +1,6 @@
 ---
 title: "Myth versus Fact"
-excerpt: "There are some statements that cities or elected officials have been making that are incorrect regarding DART and their services, funding, or safety. DATA has complied some of them and debunked every myth."
+excerpt: "There are some statements that cities or elected officials have been making that are incorrect regarding DART and their services, funding, or safety. DATA has compiled some of them and debunked every myth."
 coverImage: "/assets/blog/dart-cuts/cover.jpg"
 date: "2024-07-27T05:00:00.000Z"
 author:
@@ -12,7 +12,7 @@ ogImage:
 
 # Myth versus Fact
 
-There are some statements that cities or elected officials have been making that are incorrect regarding DART and their services, funding, or safety. DATA has complied some of them and debunked every myth. 
+There are some statements that cities or elected officials have been making that are incorrect regarding DART and their services, funding, or safety. DATA has compiled some of them and debunked every myth. 
 
 ---
 ## Myth: DART's sales tax cut won't impact service.
@@ -35,7 +35,7 @@ Without careful consideration, these cuts could jeopardize critical projects lik
 *Source: DART News Release on [Vinyl Seat Upgrade](https://dart.org/about/news-and-events/newsreleases/newsrelease-detail/dart-completes-vinyl-seat-upgrade-on-light-rail-vehicle-fleet) and on [Security Enhancements](https://www.dart.org/about/news-and-events/newsreleases/newsrelease-detail/dart-enhances-security-focus-with-contract-security-officers), [Dallas Express](https://dallasexpress.com/city/dart-focuses-on-improving-security-sanitation/)*
 
 ## Myth: DART is not investing in rider amenities.
-**Fact**: DART is modernizing its infrastructure with new Next Generation Bus Shelters designed by UTA students from the College of Architecture, Planning, and Public Affairs with a focus on safety, climate control, adaptability, and enhanced rider experience. These shelters will also feature Real Time Displays for bus arrival information.   
+**Fact**: DART is modernizing its infrastructure with new Next Generation Bus Shelters designed by University of Texas at Arlington students with a focus on safety, climate control, adaptability, and enhanced rider experience. These shelters will also feature Real Time Displays for bus arrival information.   
 *Source/Attributions: [Reddit/DART Opr8r](https://www.reddit.com/r/dart/comments/1e7mgr9/next_gen_bus_shelter_lighting_standard_size/), [DART Daily](https://dartdaily.dart.org/home/architecture-students-help-design-darts-next-bus-shelters), [DART Press Release](https://www.dart.org/about/news-and-events/newsreleases/newsrelease-detail/dart-pilot-program-to-test-next-generation-bus-shelters)*
 
 ## Myth: DART is not contributing to local development.


### PR DESCRIPTION
Rewords a few sentences for clarity/concision, adds missing punctuation, and merges the first two myths regarding sales tax cuts affecting service.