### PR TITLE
About page formatting

### DIFF
--- a/src/app/_components/cover-image.tsx
+++ b/src/app/_components/cover-image.tsx
@@ -18,6 +18,7 @@ const CoverImage = ({ title, src, slug }: Props) => {
       })}
       width={1300}
       height={630}
+      priority
     />
   );
   return (

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -1,28 +1,44 @@
 export default function Index() {
   return (
-    <>
-      <h1 className="my-16 md:mb-6 text-5xl md:text-8xl font-bold tracking-tighter leading-tight md:pr-8">
+    <div className="leading-tight">
+      <div className="my-12 md:my-16 md:mb-12 text-5xl md:text-8xl font-bold tracking-tighter">
+        About Us
+      </div>
+      <div className="text-2xl md:text-3xl mt-8 md:mt-12 mb-4 font-bold">
         Our Mission
-      </h1>
-      <div>
-        <h2 className="text-3xl mt-12 mb-4 leading-tight">
-          Fighting for affordable, accessible, and reliable public transit for the continually growing Dallas area.
-        </h2>
       </div>
-      <div>
-        <h1 className="my-8 md:mb-3 md:text-4xl font-bold leading-tight">
-          About Us
-        </h1>
+      <div className="text-lg">
+        Fighting for affordable, accessible, and reliable public transit for the
+        continually growing Dallas area.
       </div>
-      <div className="my-8 md:mb-6 text-2xl md:text-2xl leading-tight md:pr-8">
-        Since forming in 2024, the Dallas Area Transit Alliance (DATA) has become a movement to shine a light on vital issues with public transit in Dallas and the surrounding cities.  DATA has mobilized to address concerns with local officials and representatives, organized with our local communities, and correspond with media to make our voices heard.  We are committed to improving public transit holistically, including advocating for better land use.
+      <div className="text-2xl md:text-3xl mt-8 md:mt-12 mb-4 font-bold">
+        History
       </div>
-      <div className="mb-4 font-bold">Our goals are simple but evergreen:</div>
-      <ol className="mb-16 md:mb-12 text-1xl leading-tight">
-        <li>1. Ensure public transit remains a viable option for everyone in the Dallas area </li>
-        <li>2. Engage and collaborate with elected officials to promote transit positive agendas</li>
-        <li>3. Identify problem areas with transit and provide desirable solutions</li>
+      <div className="text-lg">
+        Since forming in 2024, the Dallas Area Transit Alliance (DATA) has
+        become a movement to shine a light on vital issues with public transit
+        in Dallas and the surrounding cities. DATA has mobilized to address
+        concerns with local officials and representatives, organized with our
+        local communities, and correspond with media to make our voices heard.
+        We are committed to improving public transit holistically, including
+        advocating for better land use.
+      </div>
+      <div className="text-2xl md:text-3xl mt-8 md:mt-12 mb-4 font-bold">
+        Goals:
+      </div>
+      <ol className="mb-16 md:mb-12 text-lg">
+        <li className="mb-1">
+          1. Ensure public transit remains a viable option for everyone in the
+          Dallas area
+        </li>
+        <li className="mb-1">
+          2. Engage and collaborate with elected officials to promote transit
+          positive agendas
+        </li>
+        <li className="mb-1">
+          3. Identify problem areas with transit and provide desirable solutions
+        </li>
       </ol>
-    </>
+    </div>
   );
 }


### PR DESCRIPTION
1. I like the content but I think there are too many different font sizes/styles on this page, so I standardized it to a few different ones to be more consistent
2. I think clicking on "About" should show "About" or "About Us" as the page title, so I reordered some things

Before desktop:

![image](https://github.com/user-attachments/assets/a05591a5-156d-4479-9474-613e667db831)

After desktop:
![image](https://github.com/user-attachments/assets/533765eb-c43f-4419-b48f-5d3cc98f1df7)

___

Before mobile:
![image](https://github.com/user-attachments/assets/0b4a8e7e-f712-45a7-a9fa-306dc0605a83)


After mobile:
![image](https://github.com/user-attachments/assets/222e0eb7-f22a-4ce2-bb4c-87240cc49c8c)
