### PR TITLE
Move theme switcher to navbar

### DIFF
--- a/src/app/_components/navbar.tsx
+++ b/src/app/_components/navbar.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from "react";
 import { Logo } from "@/app/_components/logo";
+import { ThemeSwitcher } from "./theme-switcher";
 
 export const Navbar2 = () => {
   const [isOpen, setIsOpen] = useState(false);
@@ -37,7 +38,7 @@ export const Navbar = () => {
       <div className="flex flex-wrap items-center justify-between mx-auto py-4">
         <a href="/" className="flex items-center space-x-3 rtl:space-x-reverse">
           <Logo className="w-24 max-lg:w-16" />
-          <span className="self-center text-3xl max-lg:text-2xl max-md:text-xl max-md:text-lg font-semibold whitespace-nowrap">
+          <span className="self-center text-3xl max-lg:text-2xl max-md:text-xl font-semibold whitespace-nowrap">
             Dallas Area Transit Alliance
           </span>
         </a>
@@ -69,7 +70,7 @@ export const Navbar = () => {
             isOpen ? "" : "hidden"
           }`}
         >
-          <ul className="font-medium flex flex-col p-4 md:p-0 mt-4 border border-slate-100 rounded-lg bg-slate-50 md:flex-row md:space-x-8 rtl:space-x-reverse md:mt-0 md:border-0 md:bg-white dark:bg-slate-800 md:dark:bg-slate-900 dark:border-slate-700">
+          <ul className="font-medium flex flex-col md:items-center p-4 md:p-0 mt-4 border border-slate-100 rounded-lg bg-slate-50 md:flex-row md:space-x-8 rtl:space-x-reverse md:mt-0 md:border-0 md:bg-white dark:bg-slate-800 md:dark:bg-slate-900 dark:border-slate-700 leading-none">
             <li>
               <a
                 href="/"
@@ -104,6 +105,11 @@ export const Navbar = () => {
               >
                 Contact
               </a>
+            </li>
+            <li>
+              <div className="flex items-center h-8 px-3 md:h-auto md:p-0">
+                <ThemeSwitcher />
+              </div>
             </li>
           </ul>
         </div>

--- a/src/app/_components/navbar.tsx
+++ b/src/app/_components/navbar.tsx
@@ -66,7 +66,7 @@ export const Navbar = () => {
           </svg>
         </button>
         <div
-          className={`md:block md:w-auto max-md:mr-2 max-md:absolute top-16 right-0 ${
+          className={`md:mt-4 lg:mt-0 md:block md:w-auto max-md:mr-2 max-md:absolute top-16 right-0 ${
             isOpen ? "" : "hidden"
           }`}
         >

--- a/src/app/_components/switch.module.css
+++ b/src/app/_components/switch.module.css
@@ -1,8 +1,5 @@
 .switch {
   all: unset;
-  position: absolute;
-  right: 20px;
-  top: 70px;
   display: inline-block;
   color: currentColor;
   border-radius: 50%;
@@ -15,7 +12,7 @@
 }
 
 [data-mode="system"] .switch::after {
-  position: absolute;
+  position: relative;
   height: 100%;
   width: 100%;
   top: 0;
@@ -37,7 +34,8 @@
 [data-mode="dark"] .switch {
   box-shadow: calc(var(--size) / 4) calc(var(--size) / -4) calc(var(--size) / 8)
     inset #fff;
-  border: none;
+  /* keep a 1px border so it doesn't shift around when switching */
+  border: 1px solid transparent;
   background: transparent;
   animation: n linear 0.5s;
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -6,7 +6,6 @@ import { SpeedInsights } from "@vercel/speed-insights/next";
 import "./globals.css";
 import Footer from "@/app/_components/footer";
 import type { Metadata } from "next";
-import { ThemeSwitcher } from "@/app/_components/theme-switcher";
 import Container from "@/app/_components/container";
 import { Navbar } from "@/app/_components/navbar";
 
@@ -64,7 +63,6 @@ export default function RootLayout({
       <body
         className={cn(inter.className, "dark:bg-slate-900 dark:text-slate-400")}
       >
-        <ThemeSwitcher />
         <div className="min-h-screen">
           <main>
             <Container>


### PR DESCRIPTION
Before desktop:
![image](https://github.com/user-attachments/assets/15d15c18-f422-4149-a0ad-70017e6fd145)

After desktop:
![image](https://github.com/user-attachments/assets/8675a811-f54c-4a10-bb79-2cc3647fbd2f)

Before mobile:
![image](https://github.com/user-attachments/assets/9fe5b126-8069-4bb3-a0a2-eb3b1a2a4a5f)

After mobile:
![image](https://github.com/user-attachments/assets/ae9b0511-45ab-4a16-8452-e742053618e6)

One issue is that on the medium breakpoint the navbar becomes too wide and wraps around:
![image](https://github.com/user-attachments/assets/81b2b733-f475-45bd-b286-3844567dd859)
I've just accepted this and added some margin between the logo and navbar. We could also decrease the size of the logo (again), or move the petition link somewhere else 🙂 