### PR TITLE
Update email link

### DIFF
--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -40,7 +40,7 @@ export default function Index() {
 
         <div className="mb-2 mt-10">Press Contact</div>
         <div className="font-semibold dark:text-white dark:font-normal">
-          info@ridewithdata.org
+         <a href="mailto:info@ridewithdata.org">info@ridewithdata.org</a>
         </div>
       </div>
     </>


### PR DESCRIPTION
I made a change to the Contact Us page to add the email address as a link to open in their preferred email client. (Useful for mobile)

![image](https://github.com/user-attachments/assets/423b8c05-7483-44d6-83c3-27fbefb89c77)
![image](https://github.com/user-attachments/assets/49e3b787-af96-4b4b-99e4-389847064d97)
