### PR TITLE
Standardize author names

### DIFF
--- a/_posts/dart-workshop-01-2025-response.md
+++ b/_posts/dart-workshop-01-2025-response.md
@@ -4,7 +4,7 @@ excerpt: "The upcoming DART Board working sessions are expected to discuss key d
 coverImage: "/assets/blog/dart-workshop-01-25-response/cover.png"
 date: "2025-01-07T05:00:00.000Z"
 author:
-  name: DATA Alert
+  name: DATA Team
   picture: "/assets/blog/authors/data-team.png"
 ogImage:
   url: "/assets/blog/dart-workshop-01-25-response/cover.png"

--- a/_posts/data-announces-formation.md
+++ b/_posts/data-announces-formation.md
@@ -4,7 +4,7 @@ excerpt: "Today we officially announce the formation of the Dallas Area Transit 
 coverImage: "/assets/blog/data-announces-formation/cover.jpg"
 date: "2024-07-30T05:00:00.000Z"
 author:
-  name: DATA Press Release
+  name: DATA Team
   picture: "/assets/blog/authors/data-team.png"
 ogImage:
   url: "/assets/blog/data-announces-formation/cover.jpg"

--- a/_posts/data-election-results-sept-2024.md
+++ b/_posts/data-election-results-sept-2024.md
@@ -4,7 +4,7 @@ excerpt: "On September 21, 2024, the Dallas Area Transit Alliance (DATA) convene
 coverImage: "/assets/blog/data-election-results-sept-2024/cover.jpg"
 date: "2024-09-21T05:00:00.000Z"
 author:
-  name: DATA Press Release
+  name: DATA Team
   picture: "/assets/blog/authors/data-team.png"
 ogImage:
   url: "/assets/blog/data-election-results-sept-2024/cover.jpg"

--- a/_posts/data-statement-01-08-2025.md
+++ b/_posts/data-statement-01-08-2025.md
@@ -4,7 +4,7 @@ excerpt: "The DART board is discussing cutting back fixed route bus service in P
 coverImage: "/assets/blog/dart-workshop-01-25-response/cover.png"
 date: "2025-01-09T05:00:00.000Z"
 author:
-  name: DATA Alert
+  name: DATA Team
   picture: "/assets/blog/authors/data-team.png"
 ogImage:
   url: "/assets/blog/dart-workshop-01-25-response/cover.png"

--- a/_posts/data-statement-plano-ila.md
+++ b/_posts/data-statement-plano-ila.md
@@ -4,7 +4,7 @@ excerpt: "On December 18, 2024, the DART Board of Directors held a workshop to d
 coverImage: "/assets/blog/data-statement-plano-ila/cover.jpg"
 date: "2024-12-20T05:00:00.000Z"
 author:
-  name: DATA Executive Committee
+  name: DATA Team
   picture: "/assets/blog/authors/data-team.png"
 ogImage:
   url: "/assets/blog/data-statement-plano-ila/cover.jpg"

--- a/_posts/fy25-dart-budget-proposal-response.md
+++ b/_posts/fy25-dart-budget-proposal-response.md
@@ -4,7 +4,7 @@ excerpt: "Contact the DART Board and tell them that you oppose DART funding caps
 coverImage: "/assets/blog/fy25-dart-budget-proposal-response/cover.png"
 date: "2024-08-12T05:00:00.000Z"
 author:
-  name: DATA Alert
+  name: DATA Team
   picture: "/assets/blog/authors/data-team.png"
 ogImage:
   url: "/assets/blog/fy25-dart-budget-proposal-response/cover.png"

--- a/_posts/january-2025-newsletter.md
+++ b/_posts/january-2025-newsletter.md
@@ -4,7 +4,7 @@ excerpt: "Happy New Year from all of us at DATA! We have a great newsletter with
 coverImage: "/assets/default/fair-park-station.jpg"
 date: "2025-01-01T05:00:00.000Z"
 author:
-  name: DATA Team
+  name: DATA Newsletter
   picture: "/assets/blog/authors/data-team.png"
 ogImage:
   url: "/assets/default/fair-park-station.jpg"

--- a/_posts/january-2025-newsletter.md
+++ b/_posts/january-2025-newsletter.md
@@ -4,7 +4,7 @@ excerpt: "Happy New Year from all of us at DATA! We have a great newsletter with
 coverImage: "/assets/default/fair-park-station.jpg"
 date: "2025-01-01T05:00:00.000Z"
 author:
-  name: DATA Newsletter
+  name: DATA Team
   picture: "/assets/blog/authors/data-team.png"
 ogImage:
   url: "/assets/default/fair-park-station.jpg"

--- a/_posts/remembering-mary.md
+++ b/_posts/remembering-mary.md
@@ -4,7 +4,7 @@ excerpt: "A Friend, Advocate, and Champion of DATA. Your passion and commitment 
 coverImage: "/assets/blog/remembering-mary/cover.jpg"
 date: "2025-01-25T05:00:00.000Z"
 author:
-  name: DATA Executive Committee
+  name: DATA Team
   picture: "/assets/blog/authors/data-team.png"
 ogImage:
   url: "/assets/blog/remembering-mary/cover.jpg"


### PR DESCRIPTION
- Changed `DATA Alert`, `Press Release`, and `Executive Committee` to `DATA Team`
- Keep `DATA Newsletter` since it's a consistent thing