### PR TITLE
Larger name on mobile

### DIFF
--- a/src/app/_components/navbar.tsx
+++ b/src/app/_components/navbar.tsx
@@ -24,7 +24,7 @@ export const Navbar = () => {
           className="flex items-center space-x-3 rtl:space-x-reverse"
         >
           <Logo className="w-24 max-lg:w-16 max-md:w-12" />
-          <span className="self-center text-3xl max-lg:text-2xl max-md:text-xl max-sm:text-lg max-[420px]:text-sm font-semibold whitespace-nowrap">
+          <span className="self-center text-3xl max-lg:text-2xl max-md:text-xl max-sm:text-lg max-[420px]:text-base font-semibold whitespace-nowrap">
             Dallas Area Transit Alliance
           </span>
         </Link>


### PR DESCRIPTION
Before
![image](https://github.com/user-attachments/assets/ccf39163-194b-46cc-83ab-8942074869c0)

After
![image](https://github.com/user-attachments/assets/27ea487c-5ff4-400e-afc1-918cf60f5a7c)
