### PR TITLE
Fix DART member cities count and update list

### DIFF
--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -67,9 +67,9 @@ export default function Index() {
           <i>Dallas Area Transit Alliance</i>, or <i>DATA</i>, was formed in
           response to a wave of{" "}
           <a href="/posts/dart-cuts">city council resolutions</a> aimed at
-          reducing DART funding. Our organization represents all 13 DART member
+          reducing DART funding. Our organization represents all 12 DART member
           cities: Dallas, Addison, Carrollton, Cockrell Hill, Farmers Branch,
-          Garland, Glenn Heights, Highland Park, Irving, Plano, Richardson,
+          Garland, Glenn Heights, Irving, Plano, Richardson,
           Rowlett, and University Park.
         </p>
 


### PR DESCRIPTION
Updated the number of DART member cities from 13 to 12 and adjusted the list accordingly.